### PR TITLE
Target `buster` distribution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.6-buster
 
 ENV PYTHONUNBUFFERED 1
 RUN mkdir /code


### PR DESCRIPTION
As @bonniegee discovered, the `python:3.6` tag was pointing to the `bullseye` debian distribution, which was causing issues when building `libpaper1`. 

Instead of targeting the `python:3.6` base, we now target the `python:3.6-buster` base, which uses the `buster` distribution (rather than `bullseye`). 

fixes #34 