### PR TITLE
Move AWS upload logic

### DIFF
--- a/create_derivatives/clients.py
+++ b/create_derivatives/clients.py
@@ -49,14 +49,19 @@ class AWSClient:
             aws_secret_access_key=secret_key)
         self.bucket = bucket
 
-    def upload_file_to_bucket(self, filepath, target_dir, content_type):
-        """Uploads a file to a directory in a bucket
+    def upload_files(self, files, destination_dir):
+        """Iterates over directories and conditionally uploads files to S3.
 
         Args:
-            filepath (pathlib.Path): path to file to upload
-            target_dir (str): target directory in bucket
-            content_type (str): MIME type for file to upload
+            files (list): Filepaths to be uploaded.
+            destination_dir (str): Path in the bucket in which the file should be stored.
         """
-        key = filepath.stem
-        bucket_path = str(Path(target_dir, key))
-        return self.s3.meta.client.upload_file(str(filepath), self.bucket, bucket_path, ExtraArgs={'ContentType': content_type})
+        for file in files:
+            key = file.stem
+            bucket_path = str(Path(destination_dir, key))
+            content_type = "image/jp2"
+            if file.suffix == ".json":
+                content_type = "application/json"
+            elif file.suffix == ".pdf":
+                content_type = "application/pdf"
+            return self.s3.meta.client.upload_file(str(file), self.bucket, bucket_path, ExtraArgs={'ContentType': content_type})

--- a/create_derivatives/clients.py
+++ b/create_derivatives/clients.py
@@ -64,4 +64,4 @@ class AWSClient:
                 content_type = "application/json"
             elif file.suffix == ".pdf":
                 content_type = "application/pdf"
-            return self.s3.meta.client.upload_file(str(file), self.bucket, bucket_path, ExtraArgs={'ContentType': content_type})
+            self.s3.meta.client.upload_file(str(file), self.bucket, bucket_path, ExtraArgs={'ContentType': content_type})

--- a/create_derivatives/clients.py
+++ b/create_derivatives/clients.py
@@ -49,19 +49,14 @@ class AWSClient:
             aws_secret_access_key=secret_key)
         self.bucket = bucket
 
-    def upload_files(self, files, destination_dir):
-        """Iterates over directories and conditionally uploads files to S3.
+    def upload_file_to_bucket(self, filepath, target_dir, content_type):
+        """Uploads a file to a directory in a bucket
 
         Args:
-            files (list): Filepaths to be uploaded.
-            destination_dir (str): Path in the bucket in which the file should be stored.
+            filepath (pathlib.Path): path to file to upload
+            target_dir (str): target directory in bucket
+            content_type (str): MIME type for file to upload
         """
-        for file in files:
-            key = file.stem
-            bucket_path = str(Path(destination_dir, key))
-            content_type = "image/jp2"
-            if file.suffix == ".json":
-                content_type = "application/json"
-            elif file.suffix == ".pdf":
-                content_type = "application/pdf"
-            return self.s3.meta.client.upload_file(str(file), self.bucket, bucket_path, ExtraArgs={'ContentType': content_type})
+        key = filepath.stem
+        bucket_path = str(Path(target_dir, key))
+        return self.s3.meta.client.upload_file(str(filepath), self.bucket, bucket_path, ExtraArgs={'ContentType': content_type})

--- a/create_derivatives/routines.py
+++ b/create_derivatives/routines.py
@@ -388,21 +388,12 @@ class AWSUpload(BaseRoutine):
         pdf_dir = Path(bag.bag_path, "data", "PDF")
         jp2_dir = Path(bag.bag_path, "data", "JP2")
         manifest_dir = Path(bag.bag_path, "data", "MANIFEST")
-        for src_dir in [pdf_dir, jp2_dir, manifest_dir]:
-            self.upload_files(bag, src_dir)
-
-    def upload_files(self, bag, src_dir):
-        files_to_upload = matching_files(src_dir, prefix=bag.dimes_identifier, prepend=True)
-        for filepath in files_to_upload:
-            target_dir = "images"
-            content_type = "image/jp2"
-            if filepath.suffix == ".json":
-                target_dir = "manifests"
-                content_type = "application/json"
-            elif filepath.suffix == ".pdf":
-                target_dir = "pdfs"
-                content_type = "application/pdf"
-            self.aws_client.upload_file_to_bucket(filepath, target_dir, content_type)
+        for src_dir, target_dir in [
+                (pdf_dir, "pdfs"),
+                (jp2_dir, "images"),
+                (manifest_dir, "manifests")]:
+            uploads = matching_files(src_dir, prefix=bag.dimes_identifier, prepend=True)
+            self.aws_client.upload_files(uploads, target_dir)
 
 
 class Cleanup(BaseRoutine):

--- a/create_derivatives/tests.py
+++ b/create_derivatives/tests.py
@@ -249,7 +249,7 @@ class AWSUploadTestCase(TestCase):
     fixtures = ["uploaded.json"]
 
     @patch("create_derivatives.clients.AWSClient.__init__")
-    @patch("create_derivatives.clients.AWSClient.upload_files")
+    @patch("create_derivatives.routines.AWSUpload.upload_files")
     def test_run(self, mock_upload_files, mock_init):
         """Asserts that the run method produces the desired results message.
 
@@ -263,7 +263,6 @@ class AWSUploadTestCase(TestCase):
         self.assertEqual(len(object_list), 1)
         for bag in Bag.objects.all().filter(dimes_identifier="sdfjldskj"):
             self.assertEqual(bag.process_status, Bag.UPLOADED)
-        self.assertEqual(mock_upload_files.call_count, 3)
 
 
 class CleanupTestCase(TestCase):
@@ -304,7 +303,7 @@ class ClientsTestCase(TestCase):
                 self.assertTrue(key in object)
 
     @patch("boto3.s3.transfer.S3Transfer.upload_file")
-    def test_upload_files(self, mock_upload):
+    def test_upload_file_to_bucket(self, mock_upload):
         success_message = "success"
         mock_upload.return_value = success_message
         aws = AWSClient(*settings.AWS)
@@ -312,8 +311,8 @@ class ClientsTestCase(TestCase):
             for filename, key, target_dir, mimetype in [
                     ("123456.json", "123456", "manifests", "application/json"),
                     ("123456.jp2", "123456", "images", "image/jp2"),
-                    ("123456.pdf", "123456", "pdfs", "application/pdf"), ]:
-                self.assertEqual(aws.upload_files([Path(filename)], target_dir), success_message)
+                    ("123456.pdf", "123456", "pdfs", "application/pdf")]:
+                self.assertEqual(aws.upload_file_to_bucket(Path(filename), target_dir, mimetype), success_message)
                 mock_upload.assert_called_with(
                     bucket=settings.AWS[3],
                     callback=None,

--- a/create_derivatives/tests.py
+++ b/create_derivatives/tests.py
@@ -305,15 +305,13 @@ class ClientsTestCase(TestCase):
 
     @patch("boto3.s3.transfer.S3Transfer.upload_file")
     def test_upload_files(self, mock_upload):
-        success_message = "success"
-        mock_upload.return_value = success_message
         aws = AWSClient(*settings.AWS)
         with Stubber(aws.s3.meta.client):
             for filename, key, target_dir, mimetype in [
                     ("123456.json", "123456", "manifests", "application/json"),
                     ("123456.jp2", "123456", "images", "image/jp2"),
                     ("123456.pdf", "123456", "pdfs", "application/pdf"), ]:
-                self.assertEqual(aws.upload_files([Path(filename)], target_dir), success_message)
+                aws.upload_files([Path(filename)], target_dir)
                 mock_upload.assert_called_with(
                     bucket=settings.AWS[3],
                     callback=None,

--- a/requirements.in
+++ b/requirements.in
@@ -1,12 +1,11 @@
 ArchivesSnake==0.9.1
 asterism==0.7.2
-boto3==1.18.36
+boto3==1.18.55
 Django==3.2.7
 djangorestframework==3.12.4
 health-check==3.4.1
 img2pdf==0.4.1
 iiif-prezi==0.3.0
-Pillow==8.3.1
 psycopg2-binary==2.9.1
 shortuuid==1.0.1
 git+https://github.com/IIIF/prezi-2-to-3@6fb21e0643e47e7fb9cbf8468d5bfa0de258aa13

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,17 +16,17 @@ bagit==1.8.1
     # via asterism
 boltons==21.0.0
     # via archivessnake
-boto3==1.18.36
+boto3==1.18.55
     # via -r requirements.in
-botocore==1.21.36
+botocore==1.21.55
     # via
     #   boto3
     #   s3transfer
-cachetools==4.2.2
+cachetools==4.2.4
     # via pyld
 certifi==2021.5.30
     # via requests
-charset-normalizer==2.0.4
+charset-normalizer==2.0.6
     # via requests
 clinner==1.12.3
     # via health-check
@@ -68,17 +68,16 @@ lxml==4.6.3
     #   iiif-prezi
     #   pikepdf
     #   pyld
-more-itertools==8.8.0
+more-itertools==8.10.0
     # via archivessnake
-multidict==5.1.0
+multidict==5.2.0
     # via yarl
-odin==1.7.1
+odin==1.7.2
     # via asterism
-pikepdf==2.16.1
+pikepdf==3.1.1
     # via img2pdf
-pillow==8.3.1
+pillow==8.3.2
     # via
-    #   -r requirements.in
     #   iiif-prezi
     #   img2pdf
     #   pikepdf
@@ -90,14 +89,14 @@ pyld==2.0.3
     # via iiif-prezi
 python-dateutil==2.8.2
     # via botocore
-pytz==2021.1
+pytz==2021.3
     # via django
 pyyaml==5.4.1
     # via
     #   archivessnake
     #   health-check
     #   vcrpy
-rapidfuzz==1.4.1
+rapidfuzz==1.7.1
     # via archivessnake
 requests==2.26.0
     # via archivessnake
@@ -112,23 +111,23 @@ six==1.16.0
     #   vcrpy
 smmap==4.0.0
     # via gitdb
-sqlparse==0.4.1
+sqlparse==0.4.2
     # via django
 structlog==21.1.0
     # via archivessnake
-typing-extensions==3.10.0.0
+typing-extensions==3.10.0.2
     # via
     #   asgiref
     #   gitpython
     #   structlog
     #   yarl
-urllib3==1.26.6
+urllib3==1.26.7
     # via
     #   botocore
     #   requests
 vcrpy==4.1.1
     # via -r requirements.in
-wrapt==1.12.1
+wrapt==1.13.1
     # via vcrpy
 yarl==1.6.3
     # via vcrpy


### PR DESCRIPTION
Changes how AWS upload is handled, so that method in client only handles individual files (not a list). Also updates dependencies.

Fixes #67