### PR TITLE
Do not upload pdf

### DIFF
--- a/create_derivatives/routines.py
+++ b/create_derivatives/routines.py
@@ -428,11 +428,11 @@ class AWSUpload(BaseRoutine):
         self.aws_client = AWSClient(*settings.AWS)
 
     def process_bag(self, bag):
-        pdf_dir = Path(bag.bag_path, "data", "PDF")
+        # pdf_dir = Path(bag.bag_path, "data", "PDF")
         jp2_dir = Path(bag.bag_path, "data", "JP2")
         manifest_dir = Path(bag.bag_path, "data", "MANIFEST")
         for src_dir, target_dir in [
-                (pdf_dir, "pdfs"),
+                # (pdf_dir, "pdfs"),
                 (jp2_dir, "images"),
                 (manifest_dir, "manifests")]:
             uploads = matching_files(src_dir, prefix=bag.dimes_identifier, prepend=True)

--- a/create_derivatives/tests.py
+++ b/create_derivatives/tests.py
@@ -358,7 +358,7 @@ class AWSUploadTestCase(TestCase):
         self.assertEqual(len(object_list), 1)
         for bag in Bag.objects.all().filter(dimes_identifier="sdfjldskj"):
             self.assertEqual(bag.process_status, Bag.UPLOADED)
-        self.assertEqual(mock_upload_files.call_count, 3)
+        self.assertEqual(mock_upload_files.call_count, 2)
 
 
 class CleanupTestCase(TestCase):
@@ -406,7 +406,7 @@ class ClientsTestCase(TestCase):
             for filename, key, target_dir, mimetype in [
                     ("123456.json", "123456", "manifests", "application/json"),
                     ("123456.jp2", "123456", "images", "image/jp2"),
-                    ("123456.pdf", "123456", "pdfs", "application/pdf"), ]:
+                    ("123456.pdf", "123456", "pdfs", "application/pdf")]:
                 aws.upload_files([Path(filename)], target_dir)
                 mock_upload.assert_called_with(
                     bucket=settings.AWS[3],


### PR DESCRIPTION
Fixes an oversight in the last PR--does not upload PDF in the AWS upload service.