### PR TITLE
Update dependencies and fix readme build status url

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A microservice to create image derivatives (JPG2000 and PDF files) and IIIF Mani
 
 pictor is part of [Project Electron](https://github.com/RockefellerArchiveCenter/project_electron), an initiative to build sustainable, open and user-centered infrastructure for the archival management of digital records at the [Rockefeller Archive Center](http://rockarch.org/).
 
-[![Build Status](https://travis-ci.org/RockefellerArchiveCenter/pictor.svg?branch=base)](https://travis-ci.org/RockefellerArchiveCenter/pictor)
+[![Build Status](https://travis-ci.com/RockefellerArchiveCenter/pictor.svg?branch=base)](https://travis-ci.com/RockefellerArchiveCenter/pictor)
 
 ## Setup
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 ArchivesSnake==0.9.1
 asterism==0.7.4
-boto3==1.20.28
+boto3==1.20.38
 Django==3.2.11
 djangorestframework==3.13.1
 health-check==3.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,9 +16,9 @@ bagit==1.8.1
     # via asterism
 boltons==21.0.0
     # via archivessnake
-boto3==1.20.28
+boto3==1.20.38
     # via -r requirements.in
-botocore==1.23.28
+botocore==1.23.38
     # via
     #   boto3
     #   s3transfer
@@ -51,7 +51,7 @@ djangorestframework==3.13.1
     # via
     #   -r requirements.in
     #   asterism
-frozendict==2.1.3
+frozendict==2.2.0
     # via pyld
 gitdb==4.0.9
     # via gitpython
@@ -160,7 +160,7 @@ typing-extensions==4.0.1
     #   importlib-metadata
     #   structlog
     #   yarl
-urllib3==1.26.7
+urllib3==1.26.8
     # via
     #   botocore
     #   requests


### PR DESCRIPTION
- Updates boto3
- Uses travis.com instead of travis.org in readme build status url