### PR TITLE
Dependency Updates and Fix DRF API Template

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v5.0.0
         with:
           token: ${{ secrets.ACCESS_TOKEN }}
           ref: development

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v5.0.0
 
       - name: Export secrets to environment variables
         uses: oNaiPs/secrets-to-env-action@v1.5
@@ -65,7 +65,7 @@ jobs:
         run: sudo deploy_scripts/make_zip_django.sh $DEPLOY_ZIP_DIR $DEPLOY_ZIP_NAME
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4.2.1
+        uses: aws-actions/configure-aws-credentials@v4.3.1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v5.0.0
         with:
           submodules: true
 

--- a/create_derivatives/templates/rest_framework/api.html
+++ b/create_derivatives/templates/rest_framework/api.html
@@ -128,7 +128,7 @@
 
     <div class="response-info" aria-label="{% trans "response info" %}">
       <pre class="prettyprint"><span class="meta nocode"><b>HTTP {{ response.status_code }} {{ response.status_text }}</b>{% autoescape off %}{% for key, val in response_headers|items %}
-<b>{{ key }}:</b> <span class="lit">{{ val|break_long_headers|urlize }}</span>{% endfor %}
+<b>{{ key }}:</b> <span class="lit">{{ val|urlize }}</span>{% endfor %}
 
 </span>{{ content|urlize }}</pre>{% endautoescape %}
     </div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,27 +16,27 @@ bagit==1.9.0
     # via asterism
 boltons==25.0.0
     # via archivessnake
-boto3==1.40.0
+boto3==1.40.22
     # via
     #   -r requirements.in
     #   moto
-botocore==1.40.0
+botocore==1.40.22
     # via
     #   boto3
     #   moto
     #   s3transfer
-certifi==2025.7.14
+certifi==2025.8.3
     # via requests
 cffi==1.17.1
     # via cryptography
-charset-normalizer==3.4.2
+charset-normalizer==3.4.3
     # via
     #   pdfminer-six
     #   reportlab
     #   requests
 coloredlogs==15.0.1
     # via ocrmypdf
-cryptography==45.0.5
+cryptography==45.0.7
     # via
     #   moto
     #   pdfminer-six
@@ -69,17 +69,17 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-lxml==6.0.0
+lxml==6.0.1
     # via pikepdf
 markupsafe==3.0.2
     # via
     #   jinja2
     #   werkzeug
-more-itertools==10.7.0
+more-itertools==10.8.0
     # via archivessnake
-moto==5.1.9
+moto==5.1.11
     # via -r requirements.in
-multidict==6.6.3
+multidict==6.6.4
     # via yarl
 ocrmypdf==13.7.0
     # via -r requirements.in
@@ -120,18 +120,18 @@ pyyaml==6.0.2
     #   archivessnake
     #   responses
     #   vcrpy
-rapidfuzz==3.13.0
+rapidfuzz==3.14.0
     # via archivessnake
 reportlab==4.4.3
     # via ocrmypdf
-requests==2.32.4
+requests==2.32.5
     # via
     #   -r requirements.in
     #   archivessnake
     #   iiif-prezi3
     #   moto
     #   responses
-responses==0.25.7
+responses==0.25.8
     # via moto
 s3transfer==0.13.1
     # via boto3
@@ -145,7 +145,7 @@ structlog==25.4.0
     # via archivessnake
 tqdm==4.67.1
     # via ocrmypdf
-typing-extensions==4.14.1
+typing-extensions==4.15.0
     # via
     #   asgiref
     #   multidict
@@ -161,7 +161,7 @@ vcrpy==7.0.0
     # via -r requirements.in
 werkzeug==3.1.3
     # via moto
-wrapt==1.17.2
+wrapt==1.17.3
     # via vcrpy
 xmltodict==0.14.2
     # via moto


### PR DESCRIPTION
Dependency updates and removes break_long_headers from django-rest-framework api.html template because of DRF removing them in 13.6.1.